### PR TITLE
Add organizationId field for users

### DIFF
--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -18,6 +18,12 @@ export const add = mutation({
       throw new Error("Not Authenticated");
     }
 
+    const orgId = identity.orgId as string
+
+    if (!orgId) {
+      throw new Error("No Organization Detected")
+    }
+
     const userId = await ctx.db.insert("users", {
       name: "Delilha",
     });


### PR DESCRIPTION
Introduce organizationId as a required field for users to ensure proper association with organizations.